### PR TITLE
Implement config, recipe loader & recipe runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
     env:
       MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
     steps:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Zampy
+
+A tool for downloading Land Surface Model input data.
+
+### Name origin
+
+Named after *Zam*; [the Avestan language term for the Zoroastrian concept of "earth"](https://en.wikipedia.org/wiki/Zam).
+
+## How to use Zampy
+See the section ["using Zampy"](using_zampy.md).

--- a/docs/using_zampy.md
+++ b/docs/using_zampy.md
@@ -43,12 +43,10 @@ convert:
 You can specify multiple datasets and multiple variables per dataset.
 
 ## Running a recipe
-Save this recipe to disk and run the following code in Python (modifying the path to the file):
+Save this recipe to disk and run the following code in your shell:
 
-```py
-from zampy.recipe import RecipeManager
-r = RecipeManager(recipe_filename="/home/username/path_to_file/simple_recipe.yml")
-r.run()
+```sh
+zampy --filename /home/username/path_to_file/simple_recipe.yml
 ```
 
 This will execute the recipe (i.e. download, ingest, convert, resample and save the data).

--- a/docs/using_zampy.md
+++ b/docs/using_zampy.md
@@ -2,7 +2,7 @@
 
 ## Installing Zampy
 Zampy can be installed by doing:
-```sh
+```bash
 pip install zampy git+https://github.com/EcoExtreML/zampy
 ```
 
@@ -13,19 +13,18 @@ This file is created under your -*user's home*-/.config directory:
 
 `~/.config/zampy/zampy_config.yml`
 
-```yml
+```yaml
 working_directory: /home/bart/Zampy
-
 ```
 
 ## Formulating a recipe
 Recipes have the following structure:
 
-```yml
+```yaml
 name: "test_recipe"
 
 download:
-  years: [2019, 2020]
+  years: [2020, 2020]
   bbox: [54, 6, 50, 3] # NESW
 
   datasets:
@@ -33,6 +32,9 @@ download:
       variables:
         - 10m_v_component_of_wind
         - surface_pressure
+    eth_canopy_height:
+      variables:
+        - height_of_vegetation
 
 convert:
   convention: ALMA
@@ -45,7 +47,7 @@ You can specify multiple datasets and multiple variables per dataset.
 ## Running a recipe
 Save this recipe to disk and run the following code in your shell:
 
-```sh
+```bash
 zampy --filename /home/username/path_to_file/simple_recipe.yml
 ```
 

--- a/docs/using_zampy.md
+++ b/docs/using_zampy.md
@@ -9,16 +9,14 @@ pip install zampy git+https://github.com/EcoExtreML/zampy
 ## Configuration
 Zampy needs to be configured with a simple configuration file.
 
-This file is created under your -*user's home*-/.config directory:
-
-`~/.config/zampy/zampy_config.yml`
+You need to create this file under your -*user's home*-/.config directory: `~/.config/zampy/zampy_config.yml`, and should contain the following:
 
 ```yaml
-working_directory: /home/bart/Zampy
+working_directory: /path_to_a_working_directory/  #for example: /home/bart/Zampy
 ```
 
 ## Formulating a recipe
-Recipes have the following structure:
+A "recipe" is a file with `yml` extension and has the following structure:
 
 ```yaml
 name: "test_recipe"

--- a/docs/using_zampy.md
+++ b/docs/using_zampy.md
@@ -1,0 +1,54 @@
+# Using Zampy
+
+## Installing Zampy
+Zampy can be installed by doing:
+```sh
+pip install zampy git+https://github.com/EcoExtreML/zampy
+```
+
+## Configuration
+Zampy needs to be configured with a simple configuration file.
+
+This file is created under your -*user's home*-/.config directory:
+
+`~/.config/zampy/zampy_config.yml`
+
+```yml
+working_directory: /home/bart/Zampy
+
+```
+
+## Formulating a recipe
+Recipes have the following structure:
+
+```yml
+name: "test_recipe"
+
+download:
+  years: [2019, 2020]
+  bbox: [54, 6, 50, 3] # NESW
+
+  datasets:
+    era5:
+      variables:
+        - 10m_v_component_of_wind
+        - surface_pressure
+
+convert:
+  convention: ALMA
+  frequency: 1H  # outputs at 1 hour frequency. Pandas-like freq-keyword.
+  resolution: 0.5  # output resolution in degrees.
+```
+
+You can specify multiple datasets and multiple variables per dataset.
+
+## Running a recipe
+Save this recipe to disk and run the following code in Python (modifying the path to the file):
+
+```py
+from zampy.recipe import RecipeManager
+r = RecipeManager(recipe_filename="/home/username/path_to_file/simple_recipe.yml")
+r.run()
+```
+
+This will execute the recipe (i.e. download, ingest, convert, resample and save the data).

--- a/docs/using_zampy.md
+++ b/docs/using_zampy.md
@@ -30,9 +30,6 @@ download:
       variables:
         - 10m_v_component_of_wind
         - surface_pressure
-    eth_canopy_height:
-      variables:
-        - height_of_vegetation
 
 convert:
   convention: ALMA

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+site_name: Zampy Documentation
+
+theme:
+  name: material
+  features:
+  - navigation.instant
+  - navigation.tabs
+  - navigation.tabs.sticky
+  
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+      primary: light green
+      accent: green
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+      primary: blue grey
+      accent: teal
+
+plugins:
+  - mkdocs-jupyter:
+        include_source: True
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            docstring_options:
+              ignore_init_summary: no
+            merge_init_into_class: yes
+            show_submodules: no
+
+extra:
+  generator: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,11 +2,17 @@ site_name: Zampy Documentation
 
 theme:
   name: material
+  highlightjs: true
+  hljs_languages:
+    - yaml
+    - python
+    - bash
   features:
   - navigation.instant
   - navigation.tabs
   - navigation.tabs.sticky
-  
+  - content.code.copy
+
   palette:
     # Palette toggle for light mode
     - scheme: default
@@ -37,6 +43,15 @@ plugins:
               ignore_init_summary: no
             merge_init_into_class: yes
             show_submodules: no
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
 
 extra:
   generator: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.scripts]
+zampy="zampy.cli:run_recipe"
+
 [project.optional-dependencies]
 dev = [
   "bump2version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,13 @@ dev = [
   "pytest-cov",
   "pre-commit",
 ]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocs-jupyter",
+    "mkdocstrings[python]",
+    "mkdocs-gen-files",
+]
 
 [tool.hatch.envs.default]
 features = ["dev"]
@@ -100,6 +107,13 @@ test = ["pytest ./src/zampy/ ./tests/ --doctest-modules --doctest-ignore-import-
 coverage = [
   "pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/",
 ]
+
+[tool.hatch.envs.docs]
+features = ["docs"]
+
+[tool.hatch.envs.docs.scripts]
+build = ["mkdocs build"]
+serve = ["mkdocs serve"]
 
 # [tool.hatch.envs.conda]
 # type = "conda"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "zampy"
 description = "python package for getting Land Surface Model input data."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.11"
+requires-python = ">=3.9, <3.12"
 authors = [
   {email = "b.schilperoort@esciencecenter.nl"},
   {name = "Bart Schilperoort, Yang Liu, Fakhereh Alidoost"}
@@ -43,7 +43,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
 ]
@@ -55,6 +54,7 @@ dependencies = [
   "pandas",
   "matplotlib",
   "xarray",
+  "scipy",  # required for xarray.interpolate
   "rioxarray",  # required for TIFF files
   "tqdm",
   "dask[diagnostics]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [
 ]
 dependencies = [
   "requests",
+  "pyyaml",
   "netcdf4",
   "numpy",
   "pandas",
@@ -75,6 +76,7 @@ dev = [
   "mypy",
   "types-requests", # type stubs for request lib
   "types-urllib3", # type stubs for url lib
+  "types-PyYAML",
   "pytest",
   "pytest-cov",
   "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dev = [
   "types-PyYAML",
   "pytest",
   "pytest-cov",
+  "pytest-mock",
   "pre-commit",
 ]
 docs = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,4 +10,4 @@ sonar.links.ci=https://github.com/EcoExtreML/zampy/actions
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.xunit.reportPath=xunit-result.xml
 sonar.python.pylint.reportPaths=pylint-report.txt
-sonar.python.version=3.8, 3.9, 3.10
+sonar.python.version=3.9, 3.10, 3.11

--- a/src/zampy/cli.py
+++ b/src/zampy/cli.py
@@ -1,18 +1,15 @@
 """Implements CLI interface for Zampy."""
+from pathlib import Path
 import click
 from zampy.recipe import RecipeManager
 
 
 @click.command()
-@click.option(
-    "--filename",
-    prompt="Path to the recipe filename",
-    help="Path to the recipe filename.",
-)
-def run_recipe(filename: str) -> None:
+@click.argument("recipe", type=click.Path(exists=True, path_type=Path))
+def run_recipe(recipe: Path) -> None:
     """Run the recipe using the CLI."""
-    click.echo(f"Executing recipe: {filename}")
-    rm = RecipeManager(filename)
+    click.echo(f"Executing recipe: {recipe}")
+    rm = RecipeManager(recipe)
     rm.run()
 
 

--- a/src/zampy/cli.py
+++ b/src/zampy/cli.py
@@ -1,0 +1,20 @@
+"""Implements CLI interface for Zampy."""
+import click
+from zampy.recipe import RecipeManager
+
+
+@click.command()
+@click.option(
+    "--filename",
+    prompt="Path to the recipe filename",
+    help="Path to the recipe filename.",
+)
+def run_recipe(filename: str) -> None:
+    """Run the recipe using the CLI."""
+    click.echo(f"Executing recipe: {filename}")
+    rm = RecipeManager(filename)
+    rm.run()
+
+
+if __name__ == "__main__":
+    run_recipe()

--- a/src/zampy/datasets/__init__.py
+++ b/src/zampy/datasets/__init__.py
@@ -6,3 +6,11 @@ from zampy.datasets.eth_canopy_height import EthCanopyHeight
 
 
 __all__ = ["dataset_protocol", "validation", "EthCanopyHeight", "ERA5"]
+
+
+# This object tracks which datasets are available.
+DATASETS: dict[str, type[dataset_protocol.Dataset]] = {
+    # All lowercase key.
+    "era5": ERA5,
+    "eth_canopy_height": EthCanopyHeight,
+}

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -65,7 +65,7 @@ class RecipeManager:
         self.start_year, self.end_year = recipe["download"]["years"]
         self.timebounds = TimeBounds(
             np.datetime64(f"{self.start_year}-01-01T00:00"),
-            np.datetime64(f"{self.end_year}-12-13T23:59"),
+            np.datetime64(f"{self.end_year}-12-31T23:59"),
         )
         self.spatialbounds = SpatialBounds(*recipe["download"]["bbox"])
 
@@ -81,7 +81,7 @@ class RecipeManager:
         self.ingest_dir = Path(config["working_directory"]) / "ingest"
         self.data_dir = (
             Path(config["working_directory"]) / "output" / str(recipe["name"])
-        )  # TODO: strip illegal chars from name.
+        )
 
         # Create required directories if they do not exist yet:
         for dir in [self.data_dir, self.download_dir, self.ingest_dir]:
@@ -120,7 +120,7 @@ class RecipeManager:
             comp = dict(zlib=True, complevel=5)
             encoding = {var: comp for var in ds.data_vars}
             fname = (  # e.g. "era5_2010-2020.nc"
-                f"{dataset_name.lower()}_" f"{self.start_year}-{self.end_year}" ".nc"
+                f"{dataset_name.lower()}_{self.start_year}-{self.end_year}.nc"
             )
             ds.to_netcdf(path=self.data_dir / fname, encoding=encoding)
 

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -10,9 +10,9 @@ from zampy.datasets.dataset_protocol import SpatialBounds
 from zampy.datasets.dataset_protocol import TimeBounds
 
 
-def recipe_loader(recipe_filename: str) -> dict:
+def recipe_loader(recipe_path: Path) -> dict:
     """Load the yaml recipe into a dictionary, and do some validation."""
-    with open(recipe_filename) as f:
+    with recipe_path.open() as f:
         recipe: dict = yaml.safe_load(f)
 
     if not all(("name", "download", "convert" in recipe.keys())):
@@ -57,10 +57,10 @@ def config_loader() -> dict:
 class RecipeManager:
     """The recipe manager is used to get the required info, and then run the recipe."""
 
-    def __init__(self, recipe_filename: str) -> None:
+    def __init__(self, recipe_path: Path) -> None:
         """Instantiate the recipe manager, using a prepared recipe."""
         # Load & parse recipe
-        recipe = recipe_loader(recipe_filename)
+        recipe = recipe_loader(recipe_path)
 
         self.start_year, self.end_year = recipe["download"]["years"]
         self.timebounds = TimeBounds(

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -1,0 +1,126 @@
+""""All functionality to read and execute Zampy recipes."""
+from pathlib import Path
+from typing import Any
+import numpy as np
+import yaml
+from zampy.datasets import DATASETS
+from zampy.datasets import converter
+from zampy.datasets.dataset_protocol import Dataset
+from zampy.datasets.dataset_protocol import SpatialBounds
+from zampy.datasets.dataset_protocol import TimeBounds
+
+
+def recipe_loader(recipe_filename: str) -> dict:
+    """Load the yaml recipe into a dictionary, and do some validation."""
+    with open(recipe_filename) as f:
+        recipe: dict = yaml.safe_load(f)
+
+    if not all(("name", "download", "convert" in recipe.keys())):
+        msg = (
+            "One of the following items are missing from the recipe:\n"
+            "name, download, convert."
+        )
+        raise ValueError(msg)
+
+    if "datasets" not in recipe["download"].keys():
+        msg = "No dataset entry found in the recipe."
+        raise ValueError(msg)
+
+    if not all(("convention", "frequency", "resolution" in recipe["convert"].keys())):
+        msg = (
+            "One of the following items are missing from the recipe:\n"
+            "name, download, convert."
+        )
+        raise ValueError(msg)
+
+    return recipe
+
+
+def config_loader() -> dict:
+    """Load the zampty config and validate the contents."""
+    config_path = Path.home() / ".config" / "zampy" / "zampy_config.yml"
+
+    if not config_path.exists():
+        msg = f"No config file was found at '{config_path}'"
+        raise FileNotFoundError(msg)
+
+    with config_path.open() as f:
+        config: dict = yaml.safe_load(f)
+
+    if "working_directory" not in config.keys():
+        msg = "No `working_directory` key found in the config file."
+        raise ValueError(msg)
+
+    return config
+
+
+class RecipeManager:
+    """The recipe manager is used to get the required info, and then run the recipe."""
+
+    def __init__(self, recipe_filename: str) -> None:
+        """Instantiate the recipe manager, using a prepared recipe."""
+        # Load & parse recipe
+        recipe = recipe_loader(recipe_filename)
+
+        start_year, end_year = recipe["download"]["years"]
+        self.timebounds = TimeBounds(
+            np.datetime64(f"{start_year}"), np.datetime64(f"{end_year}")
+        )
+        self.spatialbounds = SpatialBounds(*recipe["download"]["bbox"])
+
+        self.datasets: dict[str, Any] = recipe["download"]["datasets"]
+
+        self.convention = recipe["convert"]["convention"]
+        self.frequency = recipe["convert"]["frequency"]
+        self.resolution = recipe["convert"]["resolution"]
+
+        # Load & parse config
+        config = config_loader()
+        self.download_dir = Path(config["working_directory"]) / "download"
+        self.ingest_dir = Path(config["working_directory"]) / "ingest"
+        self.data_dir = (
+            Path(config["working_directory"]) / "output" / str(recipe["name"])
+        )  # TODO: strip illegal chars from name.
+
+        # Create required directories if they do not exist yet:
+        for dir in [self.data_dir, self.download_dir, self.ingest_dir]:
+            dir.mkdir(parents=True, exist_ok=True)
+
+    def run(self) -> None:
+        """Run the full recipe."""
+        for dataset_name in self.datasets:
+            _dataset = DATASETS[dataset_name.lower()]
+            dataset: Dataset = _dataset()
+            variables: list[str] = self.datasets[dataset_name]["variables"]
+
+            # Download datset
+            dataset.download(
+                download_dir=self.download_dir,
+                time_bounds=self.timebounds,
+                spatial_bounds=self.spatialbounds,
+                variable_names=variables,
+            )
+
+            dataset.ingest(self.download_dir, self.ingest_dir)
+
+            ds = dataset.load(
+                ingest_dir=self.ingest_dir,
+                time_bounds=self.timebounds,
+                spatial_bounds=self.spatialbounds,
+                variable_names=variables,
+                resolution=self.resolution,
+                regrid_method="flox",
+            )
+
+            ds = converter.convert(ds, dataset, convention=self.convention)
+
+            ds = ds.resample(time=self.frequency).mean()
+
+            comp = dict(zlib=True, complevel=5)
+            encoding = {var: comp for var in ds.data_vars}
+            fname = (  # e.g. "era5_2010-2020.nc"
+                f"{dataset_name.lower()}_"
+                f"{self.timebounds.start}-{self.timebounds.end}"
+                ".nc"
+            )
+            ds.to_netcdf(path=self.data_dir / fname, encoding=encoding)

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -15,7 +15,7 @@ def recipe_loader(recipe_path: Path) -> dict:
     with recipe_path.open() as f:
         recipe: dict = yaml.safe_load(f)
 
-    if not all(("name", "download", "convert" in recipe.keys())):
+    if not all(key in recipe.keys() for key in ["name", "download", "convert"]):
         msg = (
             "One of the following items are missing from the recipe:\n"
             "name, download, convert."
@@ -26,7 +26,10 @@ def recipe_loader(recipe_path: Path) -> dict:
         msg = "No dataset entry found in the recipe."
         raise ValueError(msg)
 
-    if not all(("convention", "frequency", "resolution" in recipe["convert"].keys())):
+    if not all(
+        key in recipe["convert"].keys()
+        for key in ["convention", "frequency", "resolution"]
+    ):
         msg = (
             "One of the following items are missing from the recipe:\n"
             "name, download, convert."

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -62,9 +62,10 @@ class RecipeManager:
         # Load & parse recipe
         recipe = recipe_loader(recipe_filename)
 
-        start_year, end_year = recipe["download"]["years"]
+        self.start_year, self.end_year = recipe["download"]["years"]
         self.timebounds = TimeBounds(
-            np.datetime64(f"{start_year}"), np.datetime64(f"{end_year}")
+            np.datetime64(f"{self.start_year}-01-01T00:00"),
+            np.datetime64(f"{self.end_year}-12-13T23:59"),
         )
         self.spatialbounds = SpatialBounds(*recipe["download"]["bbox"])
 
@@ -119,8 +120,11 @@ class RecipeManager:
             comp = dict(zlib=True, complevel=5)
             encoding = {var: comp for var in ds.data_vars}
             fname = (  # e.g. "era5_2010-2020.nc"
-                f"{dataset_name.lower()}_"
-                f"{self.timebounds.start}-{self.timebounds.end}"
-                ".nc"
+                f"{dataset_name.lower()}_" f"{self.start_year}-{self.end_year}" ".nc"
             )
             ds.to_netcdf(path=self.data_dir / fname, encoding=encoding)
+
+        print(
+            "Finished running the recipe. Output data can be found at:\n"
+            f"    {self.data_dir}"
+        )

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -50,7 +50,7 @@ def config_loader() -> dict:
     with config_path.open() as f:
         config: dict = yaml.safe_load(f)
 
-    if "working_directory" not in config.keys():
+    if not isinstance(config, dict) or "working_directory" not in config.keys():
         msg = "No `working_directory` key found in the config file."
         raise ValueError(msg)
 

--- a/src/zampy/utils/regrid.py
+++ b/src/zampy/utils/regrid.py
@@ -105,7 +105,7 @@ def _groupby_regrid(
     ds_out = ds_out.swap_dims(
         {"latitude_bins": "latitude", "longitude_bins": "longitude"}
     )
-    ds_out = ds_out.drop(["latitude_bins", "longitude_bins"])
+    ds_out = ds_out.drop_vars(["latitude_bins", "longitude_bins"])
     return ds_out.transpose("time", "latitude", "longitude", ...)
 
 

--- a/tests/test_recipes/generate_test_data.py
+++ b/tests/test_recipes/generate_test_data.py
@@ -1,0 +1,72 @@
+"""Generates test data for running the recipe tests."""
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import xarray as xr
+from zampy.datasets.dataset_protocol import SpatialBounds
+from zampy.datasets.dataset_protocol import TimeBounds
+
+
+def generate_era5_file(
+    varname: str,
+    time_bounds: TimeBounds,
+    spatial_bounds: SpatialBounds,
+    test_value: float,
+    resolution: float,
+    time_res="1H",
+) -> xr.Dataset:
+    time_coords = pd.date_range(
+        start=time_bounds.start, end=time_bounds.end, freq=time_res, inclusive="left"
+    )
+    lat_coords = np.arange(
+        start=np.round(spatial_bounds.south - 1),
+        stop=np.round(spatial_bounds.north + 1),
+        step=resolution,
+    )
+    lon_coords = np.arange(
+        start=np.round(spatial_bounds.west - 1),
+        stop=np.round(spatial_bounds.east + 1),
+        step=resolution,
+    )
+    data = np.zeros((len(lon_coords), len(lat_coords), len(time_coords))) + test_value
+
+    ds = xr.Dataset(
+        data_vars={ERA5_LOOKUP[varname][1]: (("longitude", "latitude", "time"), data)},
+        coords={
+            "longitude": lon_coords,
+            "latitude": lat_coords,
+            "time": time_coords,
+        },
+    )
+    ds[ERA5_LOOKUP[varname][1]].attrs["units"] = ERA5_LOOKUP[varname][0]
+    ds["latitude"].attrs["units"] = "degrees_north"
+    ds["longitude"].attrs["units"] = "degrees_east"
+
+    return ds
+
+
+ERA5_LOOKUP = {  # name: (unit, fname)
+    "10m_u_component_of_wind": ("m s**-1", "u10"),
+    "10m_v_component_of_wind": ("m s**-1", "v10"),
+    "surface_pressure": ("Pa", "sp"),
+}
+
+
+def generate_era5_files(
+    directory: Path,
+    variables: list[str],
+    spatial_bounds: SpatialBounds,
+    time_bounds: TimeBounds,
+) -> None:
+    data_dir_era5 = directory / "era5"
+    data_dir_era5.mkdir()
+
+    for var in variables:
+        ds = generate_era5_file(
+            varname=var,
+            time_bounds=time_bounds,
+            spatial_bounds=spatial_bounds,
+            test_value=1.0,
+            resolution=0.25,
+        )
+        ds.to_netcdf(path=data_dir_era5 / f"era5_{var}.nc")

--- a/tests/test_recipes/recipes/era5_recipe.yml
+++ b/tests/test_recipes/recipes/era5_recipe.yml
@@ -1,0 +1,16 @@
+name: "era5_recipe"
+
+download:
+  years: [2020, 2020]
+  bbox: [51, 4, 50, 3] # NESW
+
+  datasets:
+    era5:
+      variables:
+        - 10m_v_component_of_wind
+        - surface_pressure
+
+convert:
+  convention: ALMA
+  frequency: 1H  # outputs at 1 hour frequency. Pandas-like freq-keyword.
+  resolution: 0.5  # output resolution in degrees.

--- a/tests/test_recipes/test_config_loader.py
+++ b/tests/test_recipes/test_config_loader.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import pytest
+from zampy.recipe import config_loader
+
+
+def test_valid_config(tmp_path: Path, mocker):
+    mocker.patch(
+        "pathlib.Path.home",
+        return_value=tmp_path,
+    )
+    config_dir = tmp_path / ".config" / "zampy"
+    config_dir.mkdir(parents=True)
+    valid_config = f"working_directory: {tmp_path}\n"
+    with (config_dir / "zampy_config.yml").open("w") as f:
+        f.write(valid_config)
+
+    config = config_loader()
+    assert config == {"working_directory": str(tmp_path)}
+
+
+def test_missing_config(tmp_path: Path, mocker):
+    mocker.patch(
+        "pathlib.Path.home",
+        return_value=tmp_path,
+    )
+    with pytest.raises(FileNotFoundError):
+        config_loader()
+
+
+def test_missing_key(tmp_path: Path, mocker):
+    mocker.patch(
+        "pathlib.Path.home",
+        return_value=tmp_path,
+    )
+    config_dir = tmp_path / ".config" / "zampy"
+    config_dir.mkdir(parents=True)
+    with (config_dir / "zampy_config.yml").open("w") as f:
+        f.write("nonsense")
+
+    with pytest.raises(ValueError, match="No `working_directory` key"):
+        config_loader()

--- a/tests/test_recipes/test_recipe_loader.py
+++ b/tests/test_recipes/test_recipe_loader.py
@@ -1,0 +1,80 @@
+"""Test the recipe loader."""
+import pytest
+from zampy.recipe import recipe_loader
+
+
+valid_recipe = """
+name: "Test recipe 2"
+download:
+  years: [2020, 2020]
+  bbox: [54, 6, 50, 3] # NESW
+  datasets:
+    era5:
+      variables:
+        - 10m_v_component_of_wind
+        - surface_pressure
+convert:
+  convention: ALMA
+  frequency: 1H
+  resolution: 0.5
+"""
+
+recipe_missing_datasets = """
+name: "Test recipe 2"
+download:
+  years: [2020, 2020]
+  bbox: [54, 6, 50, 3] # NESW
+convert:
+  convention: ALMA
+  frequency: 1H
+  resolution: 0.5
+"""
+
+recipe_missing_name = """
+download:
+  years: [2020, 2020]
+  bbox: [54, 6, 50, 3] # NESW
+  datasets:
+    era5:
+      variables:
+        - 10m_v_component_of_wind
+        - surface_pressure
+convert:
+  convention: ALMA
+  frequency: 1H
+  resolution: 0.5
+"""
+
+recipe_missing_convention = """
+name: "Test recipe 2"
+download:
+  years: [2020, 2020]
+  bbox: [54, 6, 50, 3] # NESW
+  datasets:
+    era5:
+      variables:
+        - 10m_v_component_of_wind
+        - surface_pressure
+convert:
+  frequency: 1H
+  resolution: 0.5
+"""
+
+
+def test_valid_recipe(tmp_path):
+    recipe_path = tmp_path / "valid_recipe.yml"
+    with recipe_path.open("w") as f:
+        f.write(valid_recipe)
+    recipe_loader(recipe_path)
+
+
+@pytest.mark.parametrize(
+    "recipe", [recipe_missing_convention, recipe_missing_datasets, recipe_missing_name]
+)
+def test_invalid_recipes(tmp_path, recipe):
+    recipe_path = tmp_path / "invalid_recipe.yml"
+    with recipe_path.open("w") as f:
+        f.write(recipe)
+
+    with pytest.raises(ValueError):
+        recipe_loader(recipe_path)

--- a/tests/test_recipes/test_simple_recipe.py
+++ b/tests/test_recipes/test_simple_recipe.py
@@ -20,7 +20,7 @@ def test_recipe(tmp_path: Path, mocker):
             "zampy.recipe.config_loader",
             return_value={"working_directory": str(tmp_path.absolute())},
         )
-        rm = RecipeManager(str(RECIPE_FILE.absolute()))
+        rm = RecipeManager(RECIPE_FILE.absolute())
 
         spatial_bounds = SpatialBounds(51, 4, 50, 3)
         time_bounds = TimeBounds(

--- a/tests/test_recipes/test_simple_recipe.py
+++ b/tests/test_recipes/test_simple_recipe.py
@@ -1,0 +1,44 @@
+"""Testing a simple recipe."""
+from pathlib import Path
+from unittest.mock import patch
+import generate_test_data
+import numpy as np
+import xarray as xr
+from zampy.datasets import DATASETS
+from zampy.datasets.dataset_protocol import SpatialBounds
+from zampy.datasets.dataset_protocol import TimeBounds
+from zampy.datasets.dataset_protocol import write_properties_file
+from zampy.recipe import RecipeManager
+
+
+RECIPE_FILE = Path(__file__).parent / "recipes" / "era5_recipe.yml"
+
+
+def test_recipe(tmp_path: Path, mocker):
+    with (patch.object(DATASETS["era5"], "download"),):
+        mocker.patch(
+            "zampy.recipe.config_loader",
+            return_value={"working_directory": str(tmp_path.absolute())},
+        )
+        rm = RecipeManager(str(RECIPE_FILE.absolute()))
+
+        spatial_bounds = SpatialBounds(51, 4, 50, 3)
+        time_bounds = TimeBounds(
+            np.datetime64("2020-01-01T00:00"), np.datetime64("2020-12-31T23:59")
+        )
+        variables = ["10m_v_component_of_wind", "surface_pressure"]
+
+        generate_test_data.generate_era5_files(
+            directory=tmp_path / "download",
+            variables=variables,
+            spatial_bounds=spatial_bounds,
+            time_bounds=time_bounds,
+        )
+        write_properties_file(
+            tmp_path / "download" / "era5", spatial_bounds, time_bounds, variables
+        )
+
+        rm.run()
+
+        ds = xr.open_mfdataset(str(tmp_path / "output" / "era5_recipe" / "*.nc"))
+        assert all(var in ds.data_vars for var in ["Psurf", "Wind_N"])


### PR DESCRIPTION
This PR implements a simple config loader, recipe loader, a recipe runner, and a CLI to run the recipes.

To review this PR: follow the instructions in docs/using_zampy.md.

- Additionally, I have set up the config required for mkdocs. The docs can now be viewed with `hatch run docs:serve`
- We can split up the recipe steps in the future, if a user only wants to re-run a single step.