### PR TITLE
Add soil temperature and soil moisture to ERA5 data, STEMMUS_SCOPE recipe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip hatch
       - name: Run fast tests first
-        run: hatch run test
+        run: hatch run fast-test
       - name: Run full test suite & coverage
         run: hatch run test
       - name: Verify that we can build the package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ python_version = "3.10"
 
 [tool.ruff]
 line-length = 88
-exclude = ["docs", "build"]
+exclude = ["docs", "build", "tests"]
 target-version = "py310"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ format = [
   "ruff check src/ tests/ --fix --exit-non-zero-on-fix",
   "lint",
 ]
-fast-test = ["pytest -m 'not slow'"]
+fast-test = ["pytest -m \"not slow\""]
 test = [
   "pytest ./src/zampy/ ./tests/ --doctest-modules --doctest-ignore-import-errors",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ markers = [
 ignore_missing_imports = true
 disallow_untyped_defs = true
 python_version = "3.10"
+exclude = "tests"
 
 [tool.ruff]
 line-length = 88

--- a/recipes/STEMMUS_SCOPE_input.yml
+++ b/recipes/STEMMUS_SCOPE_input.yml
@@ -1,0 +1,41 @@
+# config (folder, login info etc goes to a ~/.zampy/config file)
+name: "STEMMUS_SCOPE_input"
+
+download:
+  time: ["2020-01-01", "2020-06-30"]
+  bbox: [60, 10, 50, 0] # NESW
+  datasets:
+    era5_land:
+      variables:
+        - air_temperature
+        - dewpoint_temperature
+        - soil_temperature
+        - soil_moisture
+    era5:
+      variables:
+        - total_precipitation
+        - surface_thermal_radiation_downwards
+        - surface_solar_radiation_downwards
+        - surface_pressure
+        - eastward_component_of_wind
+        - northward_component_of_wind
+    eth_canopy_height:
+      variables:
+        - height_of_vegetation
+    fapar_lai:
+      variables:
+        - leaf_area_index
+    land_cover:
+      variables:
+        - land_cover
+    prism_dem_90:
+      variables:
+        - elevation
+    cams:
+      variables:
+        - co2_concentration
+
+convert:
+  convention: ALMA
+  frequency: 1H  # outputs at 1 hour frequency. Pandas-like freq-keyword.
+  resolution: 0.25  # output resolution in degrees.

--- a/src/zampy/__init__.py
+++ b/src/zampy/__init__.py
@@ -1,4 +1,5 @@
 """zampy."""
+
 from zampy import datasets
 
 

--- a/src/zampy/cli.py
+++ b/src/zampy/cli.py
@@ -8,10 +8,11 @@ from zampy.recipe import RecipeManager
 
 @click.command()
 @click.argument("recipe", type=click.Path(exists=True, path_type=Path))
-def run_recipe(recipe: Path) -> None:
+@click.option('--skip-download', is_flag=True)
+def run_recipe(recipe: Path, skip_download: bool) -> None:
     """Run the recipe using the CLI."""
     click.echo(f"Executing recipe: {recipe}")
-    rm = RecipeManager(recipe)
+    rm = RecipeManager(recipe, skip_download)
     rm.run()
 
 

--- a/src/zampy/cli.py
+++ b/src/zampy/cli.py
@@ -8,7 +8,7 @@ from zampy.recipe import RecipeManager
 
 @click.command()
 @click.argument("recipe", type=click.Path(exists=True, path_type=Path))
-@click.option('--skip-download', is_flag=True)
+@click.option("--skip-download", is_flag=True)
 def run_recipe(recipe: Path, skip_download: bool) -> None:
     """Run the recipe using the CLI."""
     click.echo(f"Executing recipe: {recipe}")

--- a/src/zampy/cli.py
+++ b/src/zampy/cli.py
@@ -1,6 +1,7 @@
 """Implements CLI interface for Zampy."""
 from pathlib import Path
 import click
+import dask.distributed
 from zampy.recipe import RecipeManager
 
 
@@ -14,4 +15,5 @@ def run_recipe(recipe: Path) -> None:
 
 
 if __name__ == "__main__":
+    dask.distributed.Client()
     run_recipe()

--- a/src/zampy/cli.py
+++ b/src/zampy/cli.py
@@ -1,4 +1,5 @@
 """Implements CLI interface for Zampy."""
+
 from pathlib import Path
 import click
 import dask.distributed

--- a/src/zampy/conventions/ALMA.json
+++ b/src/zampy/conventions/ALMA.json
@@ -84,5 +84,13 @@
     "land_cover": {
         "variable": "land_cover",
         "units": ""
+    },
+    "soil_temperature": {
+        "variable": "SoilTemp",
+        "units": "kelvin"
+    },
+    "soil_moisture": {
+        "variable": "SoilMoist",
+        "units": "kilogram/meter**3"
     }
 }

--- a/src/zampy/datasets/__init__.py
+++ b/src/zampy/datasets/__init__.py
@@ -1,4 +1,5 @@
 """Datasets implementations."""
+
 from zampy.datasets import dataset_protocol
 from zampy.datasets import validation
 from zampy.datasets.catalog import DATASETS

--- a/src/zampy/datasets/catalog.py
+++ b/src/zampy/datasets/catalog.py
@@ -1,4 +1,5 @@
 """Catalog of datasets."""
+
 from zampy.datasets import dataset_protocol
 from zampy.datasets.cams import CAMS
 from zampy.datasets.era5 import ERA5

--- a/src/zampy/datasets/cds_utils.py
+++ b/src/zampy/datasets/cds_utils.py
@@ -52,7 +52,7 @@ SPLIT_VARIABLES = {
         "soil_temperature_level_3",
         "soil_temperature_level_4",
     ),
-    "moisture_content_of_soil_layer": (
+    "soil_moisture": (
         "volumetric_soil_water_layer_1",
         "volumetric_soil_water_layer_2",
         "volumetric_soil_water_layer_3",

--- a/src/zampy/datasets/cds_utils.py
+++ b/src/zampy/datasets/cds_utils.py
@@ -1,5 +1,6 @@
 """CDS utilities used by ECMWF datasets."""
 
+from copy import copy
 from pathlib import Path
 import cdsapi
 import numpy as np
@@ -43,6 +44,21 @@ ALL_HOURS = [
     "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00",
     "21:00", "22:00", "23:00",
 ]  # fmt: skip
+
+SPLIT_VARIABLES = {
+    "soil_temperature": (
+        "soil_temperature_level_1",
+        "soil_temperature_level_2",
+        "soil_temperature_level_3",
+        "soil_temperature_level_4",
+    ),
+    "moisture_content_of_soil_layer": (
+        "volumetric_soil_water_layer_1",
+        "volumetric_soil_water_layer_2",
+        "volumetric_soil_water_layer_3",
+        "volumetric_soil_water_layer_4",
+    ),
+}
 
 
 def cds_request(
@@ -226,6 +242,12 @@ def retrieve_era5(
     # create list of year/month pairs
     year_month_pairs = time_bounds_to_year_month(time_bounds)
 
+    variables = copy(variables)  # Prevent original input from being modified in-place
+    for split_var in SPLIT_VARIABLES:
+        if split_var in variables:
+            variables.remove(split_var)
+            variables.extend(SPLIT_VARIABLES[split_var])
+
     for (year, month), variable in product(
         year_month_pairs, variables, position=0, leave=True
     ):
@@ -354,7 +376,8 @@ def convert_to_zampy(
         print(f"File '{ncfile.name}' already exists, skipping...")
     else:
         ds = parse_nc_file(file)
-
+        # Rename the vswl data:
+        ncfile = Path(str(ncfile).replace("volumetric_soil_water", "soil_moisture"))
         ds.to_netcdf(path=ncfile)
 
 
@@ -371,6 +394,28 @@ var_reference_ecmwf_to_zampy = {
     "d2m": "dewpoint_temperature",
     # cams variables
     "co2": "co2_concentration",
+}
+
+VAR_REFERENCE_MULTI_LAYER = {
+    "stl1": "soil_temperature",
+    "stl2": "soil_temperature",
+    "stl3": "soil_temperature",
+    "stl4": "soil_temperature",
+    "swvl1": "soil_moisture",
+    "swvl2": "soil_moisture",
+    "swvl3": "soil_moisture",
+    "swvl4": "soil_moisture",
+}
+
+LAYER_BOUNDS = {
+    "stl1": [[0.0, 7.0]],
+    "stl2": [[7.0, 28.0]],
+    "stl3": [[28.0, 100.0]],
+    "stl4": [[100.0, 289.0]],
+    "swvl1": [[0.0, 7.0]],
+    "swvl2": [[7.0, 28.0]],
+    "swvl3": [[28.0, 100.0]],
+    "swvl4": [[100.0, 289.0]],
 }
 
 WATER_DENSITY = 997.0  # kg/m3
@@ -415,6 +460,33 @@ def parse_nc_file(file: Path) -> xr.Dataset:
             ds[variable_name].attrs["description"] = VARIABLE_REFERENCE_LOOKUP[
                 variable_name
             ].desc
+
+        if variable in VAR_REFERENCE_MULTI_LAYER:
+            if (  # Soil temperature/moisture routine
+                str(variable).startswith("stl") or str(variable).startswith("swvl")
+            ):
+                if str(variable).startswith("swvl"):
+                    varname = "soil_moisture"
+                    standard_name = "moisture_content_of_soil_layer"
+                    ds[variable] *= WATER_DENSITY
+                    ds[variable].attrs.update({"units": "kg m**-3"})
+                else:
+                    varname = "soil_temperature"
+                    standard_name = "temperature_in_ground"
+
+                da = ds[variable]
+                name = str(da.name)
+                da = da.expand_dims({"depth": [np.mean(LAYER_BOUNDS[name])]})
+                da = da.rename(varname)
+                da.attrs.update(
+                    {
+                        "long_name": varname.replace("_", " "),
+                        "standard_name": standard_name,
+                    }
+                )
+
+                ds = da.to_dataset()
+                ds["depth_bounds"] = (("depth", "nv"), LAYER_BOUNDS[name])
 
     # TODO: add dataset attributes.
 

--- a/src/zampy/datasets/converter.py
+++ b/src/zampy/datasets/converter.py
@@ -1,4 +1,5 @@
 """Dataset formatter for different conventions."""
+
 import json
 import warnings
 from pathlib import Path

--- a/src/zampy/datasets/dataset_protocol.py
+++ b/src/zampy/datasets/dataset_protocol.py
@@ -1,4 +1,5 @@
 """Outline of the dataset protocol."""
+
 import json
 import shutil
 from dataclasses import dataclass

--- a/src/zampy/datasets/era5.py
+++ b/src/zampy/datasets/era5.py
@@ -47,15 +47,30 @@ class ERA5Land(ECMWFDataset):  # noqa: D101
     raw_variables = [
         Variable(name="t2m", unit=unit_registry.kelvin),
         Variable(name="d2m", unit=unit_registry.kelvin),
+        Variable(name="st", unit=unit_registry.kelvin),
+        Variable(name="swvl", unit=unit_registry.fraction),
     ]
 
     # variable names used in cdsapi downloading request
     cds_var_names = {
         "air_temperature": "2m_temperature",
         "dewpoint_temperature": "2m_dewpoint_temperature",
+        "soil_temperature_level_1": "soil_temperature_level_1",  # Note: split variables
+        "soil_temperature_level_2": "soil_temperature_level_2",
+        "soil_temperature_level_3": "soil_temperature_level_3",
+        "soil_temperature_level_4": "soil_temperature_level_4",
+        "volumetric_soil_water_layer_1": "volumetric_soil_water_layer_1",
+        "volumetric_soil_water_layer_2": "volumetric_soil_water_layer_2",
+        "volumetric_soil_water_layer_3": "volumetric_soil_water_layer_3",
+        "volumetric_soil_water_layer_4": "volumetric_soil_water_layer_4",
     }
 
-    variable_names = list(cds_var_names.keys())
+    variable_names = [
+        "air_temperature",
+        "dewpoint_temperature",
+        "soil_temperature",
+        "soil_moisture",
+    ]
 
     variables = [VARIABLE_REFERENCE_LOOKUP[var] for var in variable_names]
 

--- a/src/zampy/datasets/eth_canopy_height.py
+++ b/src/zampy/datasets/eth_canopy_height.py
@@ -1,4 +1,5 @@
 """ETH canopy height dataset."""
+
 import gzip
 from pathlib import Path
 import numpy as np

--- a/src/zampy/datasets/eth_canopy_height.py
+++ b/src/zampy/datasets/eth_canopy_height.py
@@ -269,10 +269,17 @@ def parse_tiff_file(file: Path, sd_file: bool = False) -> xr.Dataset:
     da = da.isel(band=0)  # get rid of band dim
     da = da.drop_vars(["band", "spatial_ref"])  # drop unnecessary coords
     ds = da.to_dataset()
-    ds = ds.assign_coords(  # halfway in the year
-        {"time": np.datetime64("2020-07-01").astype("datetime64[ns]")}
+    ds = xr.concat(  # Cover entirety of 2020
+        (
+            ds.assign_coords(
+                {"time": np.datetime64("2020-01-01").astype("datetime64[ns]")}
+            ),
+            ds.assign_coords(
+                {"time": np.datetime64("2021-01-01").astype("datetime64[ns]")}
+            ),
+        ),
+        dim="time",
     )
-    ds = ds.expand_dims("time")
     ds = ds.rename(
         {
             "band_data": "height_of_vegetation_standard_deviation"

--- a/src/zampy/datasets/fapar_lai.py
+++ b/src/zampy/datasets/fapar_lai.py
@@ -122,6 +122,7 @@ class FaparLAI:  # noqa: D101
         for file in zip_files:
             with tempfile.TemporaryDirectory(
                 dir=tmp_path,
+                # cleanup fails on windows. No clear idea on how to fix this.
                 ignore_cleanup_errors=True if os.name == "nt" else False,
             ) as _tmpdir:
                 tmpdir = Path(_tmpdir)

--- a/src/zampy/datasets/fapar_lai.py
+++ b/src/zampy/datasets/fapar_lai.py
@@ -257,6 +257,7 @@ def ingest_ncfile(ncfile: Path, ingest_folder: Path) -> None:
         path=ingest_folder / ncfile.name,
         encoding={"leaf_area_index": {"zlib": True, "complevel": 3}},
     )
+    ds.close()  # explicitly close to release file to system (for Windows)
 
 
 def extract_fapar_zip(

--- a/src/zampy/datasets/fapar_lai.py
+++ b/src/zampy/datasets/fapar_lai.py
@@ -1,5 +1,6 @@
 """Implementation of the FAPAR LAI dataset."""
 
+import os
 import shutil
 import tempfile
 import zipfile
@@ -119,7 +120,10 @@ class FaparLAI:  # noqa: D101
 
         # netCDF files follow CF-1.6, only unpacking the archives is required.
         for file in zip_files:
-            with tempfile.TemporaryDirectory(dir=tmp_path) as _tmpdir:
+            with tempfile.TemporaryDirectory(
+                dir=tmp_path,
+                ignore_cleanup_errors=True if os.name == "nt" else False,
+            ) as _tmpdir:
                 tmpdir = Path(_tmpdir)
 
                 extract_fapar_zip(

--- a/src/zampy/datasets/prism_dem.py
+++ b/src/zampy/datasets/prism_dem.py
@@ -1,4 +1,5 @@
 """Prism DEM dataset."""
+
 import gzip
 import tarfile
 from pathlib import Path

--- a/src/zampy/datasets/utils.py
+++ b/src/zampy/datasets/utils.py
@@ -1,4 +1,5 @@
 """Shared utilities from datasets."""
+
 import urllib.request
 from pathlib import Path
 import requests

--- a/src/zampy/datasets/validation.py
+++ b/src/zampy/datasets/validation.py
@@ -1,4 +1,5 @@
 """Checks for user input validation."""
+
 from pathlib import Path
 from zampy.datasets.dataset_protocol import Dataset
 from zampy.datasets.dataset_protocol import SpatialBounds

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -64,10 +64,11 @@ def config_loader() -> dict:
 class RecipeManager:
     """The recipe manager is used to get the required info, and then run the recipe."""
 
-    def __init__(self, recipe_path: Path) -> None:
+    def __init__(self, recipe_path: Path, skip_download: bool = False) -> None:
         """Instantiate the recipe manager, using a prepared recipe."""
         # Load & parse recipe
         recipe = recipe_loader(recipe_path)
+        self.skip_download = skip_download
 
         self.start_time, self.end_time = recipe["download"]["time"]
         self.timebounds = TimeBounds(
@@ -114,13 +115,14 @@ class RecipeManager:
             dataset = _dataset()
             variables: list[str] = self.datasets[dataset_name]["variables"]
 
-            # Download datset
-            dataset.download(
-                download_dir=self.download_dir,
-                time_bounds=self.timebounds,
-                spatial_bounds=self.spatialbounds,
-                variable_names=variables,
-            )
+            # Download dataset
+            if not self.skip_download:
+                dataset.download(
+                    download_dir=self.download_dir,
+                    time_bounds=self.timebounds,
+                    spatial_bounds=self.spatialbounds,
+                    variable_names=variables,
+                )
 
             dataset.ingest(self.download_dir, self.ingest_dir)
 

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -1,4 +1,4 @@
-""" "All functionality to read and execute Zampy recipes."""
+"""All functionality to read and execute Zampy recipes."""
 
 from pathlib import Path
 from typing import Any
@@ -138,8 +138,8 @@ class RecipeManager:
                 freq = xr.infer_freq(ds["time"])
                 if freq is None:  # fallback:
                     freq = (
-                        ds["time"].isel(time=1).to_numpy() -
-                        ds["time"].isel(time=0).to_numpy()
+                        ds["time"].isel(time=1).to_numpy()
+                        - ds["time"].isel(time=0).to_numpy()
                     )
                 data_freq = pd.to_timedelta(pd.tseries.frequencies.to_offset(freq))
 

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -8,6 +8,7 @@ from zampy.datasets import converter
 from zampy.datasets.dataset_protocol import Dataset
 from zampy.datasets.dataset_protocol import SpatialBounds
 from zampy.datasets.dataset_protocol import TimeBounds
+from zampy.datasets.validation import validate_download_request
 
 
 def recipe_loader(recipe_path: Path) -> dict:
@@ -92,9 +93,22 @@ class RecipeManager:
 
     def run(self) -> None:
         """Run the full recipe."""
+        # First validate all inputs (before downloading, processing...)
         for dataset_name in self.datasets:
             _dataset = DATASETS[dataset_name.lower()]
             dataset: Dataset = _dataset()
+
+            validate_download_request(
+                dataset,
+                self.download_dir,
+                self.timebounds,
+                self.spatialbounds,
+                self.datasets[dataset_name]["variables"],
+            )
+
+        for dataset_name in self.datasets:
+            _dataset = DATASETS[dataset_name.lower()]
+            dataset = _dataset()
             variables: list[str] = self.datasets[dataset_name]["variables"]
 
             # Download datset

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -1,4 +1,5 @@
-""""All functionality to read and execute Zampy recipes."""
+""" "All functionality to read and execute Zampy recipes."""
+
 from pathlib import Path
 from typing import Any
 import numpy as np

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -31,8 +31,8 @@ def recipe_loader(recipe_path: Path) -> dict:
         for key in ["convention", "frequency", "resolution"]
     ):
         msg = (
-            "One of the following items are missing from the recipe:\n"
-            "name, download, convert."
+            "One of the following 'convert' items are missing from the recipe:\n"
+            "convention, frequency, resolution."
         )
         raise ValueError(msg)
 

--- a/src/zampy/recipe.py
+++ b/src/zampy/recipe.py
@@ -141,6 +141,7 @@ class RecipeManager:
             # e.g. "era5_2010-2020.nc"
             fname = f"{dataset_name.lower()}_{time_start}-{time_end}.nc"
             ds.to_netcdf(path=self.data_dir / fname, encoding=encoding)
+            del ds
 
         print(
             "Finished running the recipe. Output data can be found at:\n"

--- a/src/zampy/reference/variables.py
+++ b/src/zampy/reference/variables.py
@@ -13,6 +13,7 @@ def unit_registration() -> UnitRegistry:
     unit_registry.define("degree_east = degree = degree_E = degreeE")
     unit_registry.define("watt_per_square_meter = watt/meter**2")
     unit_registry.define("joule_per_square_meter = joule/meter**2")
+    unit_registry.define("kilogram_per_square_meter = kilogram/(meter**2)")
     unit_registry.define(
         "kilogram_per_square_meter_second = kilogram/(meter**2*second)"
     )
@@ -56,6 +57,8 @@ VARIABLE_REFERENCE = (
     Variable("elevation", unit=unit_registry.meter),
     Variable("leaf_area_index", unit=unit_registry.fraction),
     Variable("land_cover", unit=unit_registry.dimensionless),
+    Variable("soil_temperature", unit=unit_registry.kelvin),
+    Variable("soil_moisture", unit=unit_registry.kilogram_per_square_meter),
 )
 
 VARIABLE_REFERENCE_LOOKUP = {var.name: var for var in VARIABLE_REFERENCE}

--- a/src/zampy/reference/variables.py
+++ b/src/zampy/reference/variables.py
@@ -1,4 +1,5 @@
 """Variable reference for Zampy."""
+
 from pint import UnitRegistry
 from zampy.datasets.dataset_protocol import Variable
 

--- a/tests/test_data/fapar-lai/generate_fake_data.py
+++ b/tests/test_data/fapar-lai/generate_fake_data.py
@@ -1,4 +1,5 @@
 """Generate fake data for the fapar-lai tests."""
+
 import zipfile
 from pathlib import Path
 import numpy as np

--- a/tests/test_datasets/__init__.py
+++ b/tests/test_datasets/__init__.py
@@ -1,4 +1,5 @@
 """This module contains all tests for datasets included in zampy."""
+
 from pathlib import Path
 
 

--- a/tests/test_datasets/test_eth_canopy_height.py
+++ b/tests/test_datasets/test_eth_canopy_height.py
@@ -71,7 +71,7 @@ class TestEthCanopyHeight:
         """Test ingest function."""
         ds, _ = self.ingest_dummy_data(dummy_dir)
 
-        assert type(ds) == xr.Dataset
+        assert isinstance(ds, xr.Dataset)
 
     def test_load(self, dummy_dir):
         """Test load function."""
@@ -153,7 +153,7 @@ def test_parse_tiff_file():
             "ETH_GlobalCanopyHeight_10m_2020_N51E003_Map.tif",
         )
     )
-    assert type(dummy_ds) == xr.Dataset
+    assert isinstance(dummy_ds, xr.Dataset)
 
 
 def test_convert_tiff_to_netcdf(dummy_dir):
@@ -171,4 +171,4 @@ def test_convert_tiff_to_netcdf(dummy_dir):
     ds = xr.load_dataset(
         Path(dummy_dir, "ETH_GlobalCanopyHeight_10m_2020_N51E003_Map.nc")
     )
-    assert type(ds) == xr.Dataset
+    assert isinstance(ds, xr.Dataset)

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -87,24 +87,18 @@ class TestFaparLAI:
     @pytest.mark.slow
     def test_ingest(self, dummy_dir):
         """Test ingest function."""
-        c = dask.distributed.Client()
+        dask.distributed.Client()
 
         ingest_dir = Path(dummy_dir) / "ingest"
         ingest_dir.mkdir()
 
-        def ingest_lai():
-            lai_dataset = FaparLAI()
-            lai_dataset.ingest(
-                download_dir=data_folder / "fapar-lai" / "download", ingest_dir=ingest_dir
-            )
-        f = c.submit(ingest_lai)
-        f.result()
+        lai_dataset = FaparLAI()
+        lai_dataset.ingest(
+            download_dir=data_folder / "fapar-lai" / "download", ingest_dir=ingest_dir
+        )
 
         with xr.open_mfdataset((ingest_dir / "fapar-lai").glob("*.nc")) as ds:
             assert isinstance(ds, xr.Dataset)
-
-        for file in (ingest_dir / "fapar-lai").glob("*.nc"):
-            file.unlink()
 
     def test_load(self):
         """Test load function."""

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -103,6 +103,9 @@ class TestFaparLAI:
         with xr.open_mfdataset((ingest_dir / "fapar-lai").glob("*.nc")) as ds:
             assert isinstance(ds, xr.Dataset)
 
+        for file in (ingest_dir / "fapar-lai").glob("*.nc"):
+            file.unlink()
+
     def test_load(self):
         """Test load function."""
         times = TimeBounds(np.datetime64("2019-01-01"), np.datetime64("2019-01-31"))

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -1,4 +1,5 @@
 """Unit tests for the FAPAR-LAI dataset."""
+
 import json
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -100,8 +100,8 @@ class TestFaparLAI:
         f = c.submit(ingest_lai)
         f.result()
 
-        ds = xr.open_mfdataset((ingest_dir / "fapar-lai").glob("*.nc"))
-        assert isinstance(ds, xr.Dataset)
+        with xr.open_mfdataset((ingest_dir / "fapar-lai").glob("*.nc")) as ds:
+            assert isinstance(ds, xr.Dataset)
 
     def test_load(self):
         """Test load function."""

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -100,6 +100,7 @@ class TestFaparLAI:
         with xr.open_mfdataset((ingest_dir / "fapar-lai").glob("*.nc")) as ds:
             assert isinstance(ds, xr.Dataset)
 
+    @pytest.mark.slow  # depends on ingested data being available
     def test_load(self):
         """Test load function."""
         times = TimeBounds(np.datetime64("2019-01-01"), np.datetime64("2019-01-31"))
@@ -123,6 +124,7 @@ class TestFaparLAI:
         np.testing.assert_allclose(ds.latitude.values, expected_lat)
         np.testing.assert_allclose(ds.longitude.values, expected_lon)
 
+    @pytest.mark.slow  # depends on ingested data being available
     def test_convert(self):
         """Test convert function."""
         lai_dataset = FaparLAI()

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -10,6 +10,7 @@ from zampy.datasets.catalog import FaparLAI
 from zampy.datasets.dataset_protocol import SpatialBounds
 from zampy.datasets.dataset_protocol import TimeBounds
 from . import data_folder
+import dask.distributed
 
 
 @pytest.fixture(scope="function")
@@ -86,6 +87,8 @@ class TestFaparLAI:
     @pytest.mark.slow
     def test_ingest(self, dummy_dir):
         """Test ingest function."""
+        dask.distributed.Client()
+
         ingest_dir = Path(dummy_dir) / "ingest"
         ingest_dir.mkdir()
 

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -87,15 +87,19 @@ class TestFaparLAI:
     @pytest.mark.slow
     def test_ingest(self, dummy_dir):
         """Test ingest function."""
-        dask.distributed.Client()
+        c = dask.distributed.Client()
 
         ingest_dir = Path(dummy_dir) / "ingest"
         ingest_dir.mkdir()
 
-        lai_dataset = FaparLAI()
-        lai_dataset.ingest(
-            download_dir=data_folder / "fapar-lai" / "download", ingest_dir=ingest_dir
-        )
+        def ingest_lai():
+            lai_dataset = FaparLAI()
+            lai_dataset.ingest(
+                download_dir=data_folder / "fapar-lai" / "download", ingest_dir=ingest_dir
+            )
+        f = c.submit(ingest_lai)
+        f.result()
+
         ds = xr.open_mfdataset((ingest_dir / "fapar-lai").glob("*.nc"))
         assert isinstance(ds, xr.Dataset)
 

--- a/tests/test_datasets/test_fapar_lai.py
+++ b/tests/test_datasets/test_fapar_lai.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 from unittest.mock import patch
+import dask.distributed
 import numpy as np
 import pytest
 import xarray as xr
@@ -10,7 +11,6 @@ from zampy.datasets.catalog import FaparLAI
 from zampy.datasets.dataset_protocol import SpatialBounds
 from zampy.datasets.dataset_protocol import TimeBounds
 from . import data_folder
-import dask.distributed
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_datasets/test_prism_dem.py
+++ b/tests/test_datasets/test_prism_dem.py
@@ -69,7 +69,7 @@ class TestPrismDEM:
         """Test ingest function."""
         ds, _ = self.ingest_dummy_data(dummy_dir)
 
-        assert type(ds) == xr.Dataset
+        assert isinstance(ds, xr.Dataset)
 
     def test_load(self, dummy_dir):
         """Test load function."""

--- a/tests/test_recipes/generate_test_data.py
+++ b/tests/test_recipes/generate_test_data.py
@@ -1,4 +1,5 @@
 """Generates test data for running the recipe tests."""
+
 from pathlib import Path
 import numpy as np
 import pandas as pd

--- a/tests/test_recipes/test_recipe_loader.py
+++ b/tests/test_recipes/test_recipe_loader.py
@@ -1,4 +1,5 @@
 """Test the recipe loader."""
+
 import pytest
 from zampy.recipe import recipe_loader
 

--- a/tests/test_recipes/test_simple_recipe.py
+++ b/tests/test_recipes/test_simple_recipe.py
@@ -1,4 +1,5 @@
 """Testing a simple recipe."""
+
 from pathlib import Path
 from unittest.mock import patch
 import generate_test_data

--- a/tests/test_recipes/test_simple_recipe.py
+++ b/tests/test_recipes/test_simple_recipe.py
@@ -12,6 +12,8 @@ from zampy.datasets.dataset_protocol import TimeBounds
 from zampy.datasets.dataset_protocol import write_properties_file
 from zampy.recipe import RecipeManager
 from zampy.recipe import convert_time
+import dask.distributed
+
 
 
 RECIPE_FILE = Path(__file__).parent / "recipes" / "era5_recipe.yml"
@@ -21,6 +23,8 @@ def test_recipe(tmp_path: Path, mocker):
     with (
         patch.object(DATASETS["era5"], "download"),
     ):
+        dask.distributed.Client()
+
         mocker.patch(
             "zampy.recipe.config_loader",
             return_value={"working_directory": str(tmp_path.absolute())},

--- a/tests/test_recipes/test_simple_recipe.py
+++ b/tests/test_recipes/test_simple_recipe.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from unittest.mock import patch
+import dask.distributed
 import generate_test_data
 import numpy as np
 import pytest
@@ -12,8 +13,6 @@ from zampy.datasets.dataset_protocol import TimeBounds
 from zampy.datasets.dataset_protocol import write_properties_file
 from zampy.recipe import RecipeManager
 from zampy.recipe import convert_time
-import dask.distributed
-
 
 
 RECIPE_FILE = Path(__file__).parent / "recipes" / "era5_recipe.yml"


### PR DESCRIPTION
To add these I had to merge them and add a "depth" dimension. The original files are split by layer...

Closes #47

Note that the CDS is slow, so running the recipe might take a while. Running it overnight is probably best.

Example recipe:
```yaml
# config (folder, login info etc goes to a ~/.zampy/config file)
name: "soil temperature test"

download:
  time: ["2019-01-01", "2019-01-31"]
  bbox: [54, 6, 53, 5] # NESW
  datasets:
    era5_land:
      variables:
        - soil_temperature
        - soil_moisture

convert:
  convention: ALMA
  frequency: 1H  # outputs at 1 hour frequency. Pandas-like freq-keyword.
  resolution: 0.25  # output resolution in degrees.
```